### PR TITLE
Updated submodule URLs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "gcc-lua-cdecl"]
 	path = gcc-lua-cdecl
-	url = http://git.colberg.org/gcc-lua-cdecl.git
+	url = https://git.colberg.org/gcc-lua-cdecl
 [submodule "gcc-lua"]
 	path = gcc-lua
-	url = http://git.colberg.org/gcc-lua.git
+	url = https://git.colberg.org/gcc-lua


### PR DESCRIPTION
Fixes the following error:
> fatal: unable to update url base from redirection:
>   asked for: http://git.colberg.org/gcc-lua.git/info/refs?service=git-upload-pack
>    redirect: https://git.colberg.org/gcc-lua/info/refs
> 