### PR TITLE
Update Git submodule URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "gcc-lua-cdecl"]
 	path = gcc-lua-cdecl
-	url = https://git.colberg.org/gcc-lua-cdecl
+	url = https://git.colberg.org/peter/gcc-lua-cdecl
 [submodule "gcc-lua"]
 	path = gcc-lua
-	url = https://git.colberg.org/gcc-lua
+	url = https://git.colberg.org/peter/gcc-lua


### PR DESCRIPTION
Fixes #6.

Apparently this happens regularly, cf. https://github.com/koreader/ffi-cdecl/pull/2