### PR TITLE
Attempt to leave stdint/stddef types alone

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,15 @@
-# CROSS_DIR is the main directory of the toolchain,
-# which is only used for trying to autolocate GCCPLUGIN_DIR,
-# that is set to the directory containing gcc-plugin.h
-CROSS_DIR ?= /opt/arm-2012.03
-GCCPLUGIN_DIR ?= $(shell find $(CROSS_DIR) -name gcc-plugin.h | head -n 1 | xargs dirname)
-
 # Host CC
 HOSTCC ?= gcc
 # Toolchain prefix and gcc/g++ executables
 CHOST ?= arm-none-linux-gnueabi
 CROSSCC  ?= $(CHOST)-gcc
 CROSSCXX ?= $(CHOST)-g++
+
+# CROSS_DIR is the main directory of the toolchain,
+# which is only used for trying to autolocate GCCPLUGIN_DIR,
+# that is set to the directory containing gcc-plugin.h
+CROSS_DIR ?= $(shell dirname `$(CROSSCC) -print-libgcc-file-name`)
+GCCPLUGIN_DIR ?= $(shell find $(CROSS_DIR) -name gcc-plugin.h | head -n 1 | xargs dirname)
 
 # Workaround for gcc<4.8 on arm (see http://gcc.gnu.org/PR45078)
 FIX_CPPFLAGS ?= -I$(CURDIR)/include

--- a/Makefile
+++ b/Makefile
@@ -27,9 +27,17 @@ PLUGIN_CPPFLAGS = $(CPPFLAGS) -I$(GCCPLUGIN_DIR) $(FIX_CPPFLAGS)
 PLUGIN = gcc-lua/gcc/gcclua
 PLUGINLIB = $(PLUGIN).so
 
-all: $(PLUGINLIB)
+all: | patch $(PLUGINLIB)
 
-clean:
+patch:
+	patch -d gcc-lua -p1 < gcc-lua-prefer-luajit.patch
+	patch -d gcc-lua-cdecl -p1 < gcc-lua-cdecl-do-not-mangle-c99-types.patch
+
+unpatch:
+	cd gcc-lua && git reset --hard && git clean -fxdq
+	cd gcc-lua-cdecl && git reset --hard && git clean -fxdq
+
+clean: unpatch
 	$(MAKE) -C gcc-lua clean
 
 test: test-ffi-cdecl test-gcc-lua test-gcc-lua-cdecl

--- a/ffi-cdecl.lua
+++ b/ffi-cdecl.lua
@@ -40,6 +40,8 @@ gcc.register_callback(gcc.PLUGIN_FINISH_UNIT, function()
   local result = {}
   for i, decl in ipairs(decls) do
     -- Skip the C99 decls
+    -- NOTE: Do double-check those, because while this appears to help with size_t,
+    --       I've seen *ptr_t getting mangled instead...
     if decl.id == "bool"
     or decl.id == "ptrdiff_t"
     or decl.id == "size_t"

--- a/ffi-cdecl.lua
+++ b/ffi-cdecl.lua
@@ -41,7 +41,7 @@ gcc.register_callback(gcc.PLUGIN_FINISH_UNIT, function()
   for i, decl in ipairs(decls) do
     -- Skip the C99 decls
     -- NOTE: Do double-check those, because while this appears to help with size_t,
-    --       I've seen *ptr_t getting mangled instead...
+    --       I've seen complex nested typedefs involving *ptr_t getting mangled instead...
     if decl.id == "bool"
     or decl.id == "ptrdiff_t"
     or decl.id == "size_t"

--- a/ffi-cdecl.lua
+++ b/ffi-cdecl.lua
@@ -39,7 +39,28 @@ end
 gcc.register_callback(gcc.PLUGIN_FINISH_UNIT, function()
   local result = {}
   for i, decl in ipairs(decls) do
-    result[i] = format(decl.decl, decl.id) .. ";\n"
+    -- Skip the C99 decls
+    if decl.id == "bool"
+    or decl.id == "ptrdiff_t"
+    or decl.id == "size_t"
+    or decl.id == "wchar_t"
+    or decl.id == "int8_t"
+    or decl.id == "int16_t"
+    or decl.id == "int32_t"
+    or decl.id == "int64_t"
+    or decl.id == "uint8_t"
+    or decl.id == "uint16_t"
+    or decl.id == "uint32_t"
+    or decl.id == "uint64_t"
+    or decl.id == "intptr_t"
+    or decl.id == "uintptr_t"
+    or decl.id == "ssize_t"
+    then
+        goto continue
+    end
+    table.insert(result, format(decl.decl, decl.id) .. ";\n")
+    -- That's one janky-ass workaround to the lack of continue keyword (requires LuaJIT/Lua 5.2)...
+    ::continue::
   end
   local f = assert(io.open(arg.output, "w"))
   f:write([=[

--- a/ffi-cdecl.lua
+++ b/ffi-cdecl.lua
@@ -42,6 +42,8 @@ gcc.register_callback(gcc.PLUGIN_FINISH_UNIT, function()
     -- Skip the C99 decls
     -- NOTE: Do double-check those, because while this appears to help with size_t,
     --       I've seen complex nested typedefs involving *ptr_t getting mangled instead...
+    -- NOTE: To check for suspicious type conversions, with an x86_64 compiler,
+    --       do a second run w/ -m32 in CPPFLAGS.
     if decl.id == "bool"
     or decl.id == "ptrdiff_t"
     or decl.id == "size_t"

--- a/gcc-lua-cdecl-do-not-mangle-c99-types.patch
+++ b/gcc-lua-cdecl-do-not-mangle-c99-types.patch
@@ -1,15 +1,13 @@
 diff --git a/ffi-cdecl/C99.c b/ffi-cdecl/C99.c
 new file mode 100644
-index 0000000..c4d523e
+index 0000000..1bd5698
 --- /dev/null
 +++ b/ffi-cdecl/C99.c
-@@ -0,0 +1,26 @@
+@@ -0,0 +1,24 @@
 +#include <stdbool.h>
 +#include <stddef.h>
 +#include <stdint.h>
 +#include <stdlib.h>
-+
-+#include "ffi-cdecl.h"
 +
 +// Keep types LuaJIT understands as-is
 +// (c.f., https://luajit.org/ext_ffi_semantics.html)

--- a/gcc-lua-cdecl-do-not-mangle-c99-types.patch
+++ b/gcc-lua-cdecl-do-not-mangle-c99-types.patch
@@ -1,0 +1,44 @@
+diff --git a/ffi-cdecl/C99.c b/ffi-cdecl/C99.c
+new file mode 100644
+index 0000000..c4d523e
+--- /dev/null
++++ b/ffi-cdecl/C99.c
+@@ -0,0 +1,26 @@
++#include <stdbool.h>
++#include <stddef.h>
++#include <stdint.h>
++#include <stdlib.h>
++
++#include "ffi-cdecl.h"
++
++// Keep types LuaJIT understands as-is
++// (c.f., https://luajit.org/ext_ffi_semantics.html)
++cdecl_type(bool)
++cdecl_type(ptrdiff_t)
++cdecl_type(size_t)
++cdecl_type(wchar_t)
++cdecl_type(int8_t)
++cdecl_type(int16_t)
++cdecl_type(int32_t)
++cdecl_type(int64_t)
++cdecl_type(uint8_t)
++cdecl_type(uint16_t)
++cdecl_type(uint32_t)
++cdecl_type(uint64_t)
++cdecl_type(intptr_t)
++cdecl_type(uintptr_t)
++// And we can add ssize_t to the list (c.f., src/lj_ctype.c)
++cdecl_type(ssize_t)
++
+diff --git a/ffi-cdecl/ffi-cdecl.h b/ffi-cdecl/ffi-cdecl.h
+index 7cf25d8..288b930 100644
+--- a/ffi-cdecl/ffi-cdecl.h
++++ b/ffi-cdecl/ffi-cdecl.h
+@@ -10,4 +10,7 @@
+ #define cdecl_var                       cdecl_func
+ #define cdecl_const                     cdecl_func
+ 
++// Funky workaround to ensure we'll never mangle C99 types, as well as some from <stddef.h> (mainly, size_t)
++#include "C99.c"
++
+ #endif

--- a/gcc-lua-prefer-luajit.patch
+++ b/gcc-lua-prefer-luajit.patch
@@ -1,0 +1,13 @@
+diff --git a/gcc/Makefile b/gcc/Makefile
+index ae67860..56c21eb 100644
+--- a/gcc/Makefile
++++ b/gcc/Makefile
+@@ -23,7 +23,7 @@ else
+   LDOPT   = -shared
+ endif
+ 
+-LUAMODS   = lua lua-5.3 lua5.3 lua53 lua-5.2 lua5.2 lua52 lua-5.1 lua5.1 lua51 luajit
++LUAMODS   = luajit lua-5.3 lua5.3 lua53 lua-5.2 lua5.2 lua52 lua
+ LUAMOD    = $(firstword $(foreach mod,$(LUAMODS),$(shell pkg-config --exists $(mod) && echo $(mod))))
+ ifneq (,$(LUAMOD))
+   LUACFLAGS = $(shell pkg-config --cflags $(LUAMOD))


### PR DESCRIPTION
Mainly because fixing `size_t` manually was getting tedious...

This appeared to work more-or-less okay, short of a nested `intptr_t` in MuPDF that got turned around for some mysterious reason...