### PR TITLE
Another crappy workaround for C99 typedefs

### DIFF
--- a/gcc-lua-cdecl-do-not-mangle-c99-types.patch
+++ b/gcc-lua-cdecl-do-not-mangle-c99-types.patch
@@ -29,10 +29,18 @@ index 0000000..1bd5698
 +cdecl_type(ssize_t)
 +
 diff --git a/ffi-cdecl/ffi-cdecl.h b/ffi-cdecl/ffi-cdecl.h
-index 7cf25d8..288b930 100644
+index 7cf25d8..4eb2ed5 100644
 --- a/ffi-cdecl/ffi-cdecl.h
 +++ b/ffi-cdecl/ffi-cdecl.h
-@@ -10,4 +10,7 @@
+@@ -2,6 +2,7 @@
+ #define FFI_CDECL_H
+ 
+ #define cdecl_type(id)                  void cdecl_type__ ## id(id *unused) {}
++#define cdecl_c99_type(id, c99)         void cdecl_c99_type__ ## id ## __c99__ ## c99(id *unused) {}
+ #define cdecl_memb(id)                  void cdecl_memb__ ## id(id *unused) {}
+ #define cdecl_struct(tag)               void cdecl_struct__ ## tag(struct tag *unused) {}
+ #define cdecl_union(tag)                void cdecl_union__ ## tag(union tag *unused) {}
+@@ -10,4 +11,7 @@
  #define cdecl_var                       cdecl_func
  #define cdecl_const                     cdecl_func
  
@@ -40,3 +48,30 @@ index 7cf25d8..288b930 100644
 +#include "C99.c"
 +
  #endif
+diff --git a/ffi-cdecl/ffi-cdecl.lua b/ffi-cdecl/ffi-cdecl.lua
+index bb0c1fe..54aadc2 100644
+--- a/ffi-cdecl/ffi-cdecl.lua
++++ b/ffi-cdecl/ffi-cdecl.lua
+@@ -46,15 +46,21 @@ local macro = {
+ macro.struct = macro.memb
+ macro.union = macro.memb
+ macro.enum = macro.memb
++macro.c99_type = macro.type
+ 
+ -- Parse C declaration from capture macro.
+ function _M.parse(node)
+   local name = node:name()
+   if not name then return end
+   local op, id = name:value():match("^cdecl_(.-)__(.+)")
++  -- Handle the crap c99_type workaround
++  local ref
++  if op == "c99_type" then
++    id, ref = id:match("^(.-)__c99__(.+)")
++  end
+   if not op then return end
+   local decl = macro[op](node)
+-  return decl, id
++  return decl, id, ref
+ end
+ 
+ return _M


### PR DESCRIPTION
If a typedef name points to a C99 typedef, it gets resolved down to the canonical type **for the ABI** by GCC.

We most emphatically do not want that, as it makes the result ABI-specific for a few of those.

I couldn't find a better solution that to just leave those in the hands of the programmer, via a new macro, that essentially means "leave that typedef alone, kthxbye".

(Much like the previous C99 hack, the typedef is still registered, meaning it gets picked up and used for anything else than a typedef that references it, instead of a canonical representation).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/ffi-cdecl/10)
<!-- Reviewable:end -->
