### PR TITLE
fix C99 patch

### DIFF
--- a/gcc-lua-cdecl-do-not-mangle-c99-types.patch
+++ b/gcc-lua-cdecl-do-not-mangle-c99-types.patch
@@ -2,11 +2,12 @@ diff --git a/ffi-cdecl/C99.c b/ffi-cdecl/C99.c
 new file mode 100644
 --- /dev/null
 +++ b/ffi-cdecl/C99.c
-@@ -0,0 +1,23 @@
+@@ -0,0 +1,24 @@
 +#include <stdbool.h>
 +#include <stddef.h>
 +#include <stdint.h>
 +#include <stdlib.h>
++#include <sys/types.h>
 +
 +// Keep types LuaJIT understands as-is
 +// (c.f., https://luajit.org/ext_ffi_semantics.html)


### PR DESCRIPTION
The `ssize_t` type is defined in `sys/types.h`, not including that header can result in failures at cdecls generation (e.g. on macOS with Homebrew's GCC).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/ffi-cdecl/15)
<!-- Reviewable:end -->
