### PR TITLE
ensure CPPFLAGS is honored

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ UNPATCH = git -C $1 reset --hard && git -C $1 clean -fxdq
 	$(call UNPATCH,gcc-lua)
 	$(call UNPATCH,gcc-lua-cdecl)
 	$(call APPLY_PATCH,gcc-lua,gcc-lua-gcc15.patch)
+	$(call APPLY_PATCH,gcc-lua,gcc-lua-honor-CPPFLAGS.patch)
 	$(call APPLY_PATCH,gcc-lua,gcc-lua-prefer-luajit.patch)
 	$(call APPLY_PATCH,gcc-lua-cdecl,gcc-lua-cdecl-do-not-mangle-c99-types.patch)
 	touch $@

--- a/gcc-lua-honor-CPPFLAGS.patch
+++ b/gcc-lua-honor-CPPFLAGS.patch
@@ -1,0 +1,13 @@
+diff --git i/gcc/Makefile w/gcc/Makefile
+index 296a24e..5fa9206 100644
+--- i/gcc/Makefile
++++ w/gcc/Makefile
+@@ -11,7 +11,7 @@ CPPFLAGS  =
+ CPPOPT    = -I$(shell $(TARGET_CC) -print-file-name=plugin)/include
+ CFLAGS    = -O2 -Wall -Wformat-security
+ CCOPT     = -fPIC
+-ifneq (,$(findstring GCCLUA_USE_CXX,$(shell $(HOST_CC) -E -dM $(CPPOPT) -xc++ gcclua-config.h)))
++ifneq (,$(findstring GCCLUA_USE_CXX,$(shell $(HOST_CC) -E -dM $(CPPOPT) $(CPPFLAGS) -xc++ gcclua-config.h)))
+   CCOPT  += -xc++
+ endif
+ LDFLAGS   =


### PR DESCRIPTION
Needed to build on macOS using Homebrew's GCC (with something like `make 'CPPFLAGS=-I/opt/homebrew/include -DENABLE_BUILD_WITH_CXX'`).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/ffi-cdecl/16)
<!-- Reviewable:end -->
